### PR TITLE
replace deprecated np.int usage with builtin int

### DIFF
--- a/psg_utils/hypnogram/utils.py
+++ b/psg_utils/hypnogram/utils.py
@@ -119,7 +119,7 @@ def dense_to_sparse(array, period_length, time_unit: TimeUnit = TimeUnit.SECOND,
     start_inds = np.concatenate([[0], start_inds])
 
     # Get init times (in units of period_length)
-    inits = (start_inds * period_length).astype(np.int)
+    inits = (start_inds * period_length).astype(int)
     durs = np.concatenate([np.diff(inits), [end_time-inits[-1]]])
     stages = array[start_inds]
 
@@ -395,7 +395,7 @@ def load_events_file(events_file_path):
 
     Args:
         events_file_path: Path to .ids events file
-    
+
     Returns:
         A StartDurationStage format tuple
     """

--- a/psg_utils/io/header/header_standardizers.py
+++ b/psg_utils/io/header/header_standardizers.py
@@ -278,7 +278,7 @@ def _standardized_bin_header(raw_header):
     raw_header = {key.upper(): values for key, values in raw_header.items()}
 
     # Order header entries according to CHX column
-    order = np.argsort(np.array(raw_header['CHX'], dtype=np.int))
+    order = np.argsort(np.array(raw_header['CHX'], dtype=int))
     raw_header = {key: ([entry[i] for i in order]
                         if isinstance(entry, (list, tuple, np.ndarray))
                         else entry)

--- a/psg_utils/visualization/psg_plotting.py
+++ b/psg_utils/visualization/psg_plotting.py
@@ -149,7 +149,7 @@ def plot_periods(X, y=None,
         set_equal_ylims(axes)
 
     # Set ticks at all period separation points
-    axes[-1].set_xticks(np.linspace(0, len(X), n_periods+1).astype(np.int))
+    axes[-1].set_xticks(np.linspace(0, len(X), n_periods+1).astype(int))
 
     if sample_rate is not None:
         # Set seconds on xaxis

--- a/tests/preprocessing/test_psg_sampling.py
+++ b/tests/preprocessing/test_psg_sampling.py
@@ -16,7 +16,7 @@ class TestPSGSampling:
 
         # Assert output type, should be float64 but if other versions cast to float32 that is fine as well
         assert psg_resampled.dtype in (np.float64, np.float32)
-        assert poly_resample(psg_array.astype(np.int), new_sample_rate=1, old_sample_rate=2).dtype in (np.float64, np.float32)
+        assert poly_resample(psg_array.astype(int), new_sample_rate=1, old_sample_rate=2).dtype in (np.float64, np.float32)
 
         # Test on other datatypes, should not raise an error and should give similar results
         assert np.all(np.isclose(
@@ -25,7 +25,7 @@ class TestPSGSampling:
         ))
         # Should be similar values even when cast to ints as input is integers converted to float64
         assert np.all(np.isclose(
-            poly_resample(psg_array.astype(np.int), new_sample_rate=1, old_sample_rate=2),
+            poly_resample(psg_array.astype(int), new_sample_rate=1, old_sample_rate=2),
             psg_resampled
         ))
 
@@ -36,7 +36,7 @@ class TestPSGSampling:
 
         # Assert output type, should be float64 but if other versions cast to float32 that is fine as well
         assert psg_resampled.dtype in (np.float64, np.float32)
-        assert fourier_resample(psg_array.astype(np.int), new_sample_rate=1, old_sample_rate=2).dtype in (np.float64, np.float32)
+        assert fourier_resample(psg_array.astype(int), new_sample_rate=1, old_sample_rate=2).dtype in (np.float64, np.float32)
 
         # Test on other datatypes, should not raise an error and should give similar results
         assert np.all(np.isclose(
@@ -45,7 +45,7 @@ class TestPSGSampling:
         ))
         # Should be similar values even when cast to ints as input is integers converted to float64
         assert np.all(np.isclose(
-            fourier_resample(psg_array.astype(np.int), new_sample_rate=1, old_sample_rate=2),
+            fourier_resample(psg_array.astype(int), new_sample_rate=1, old_sample_rate=2),
             psg_resampled
         ))
 


### PR DESCRIPTION
Newer versions of numpy don't support the usage of `np.int` anymore. Since `np.int` is an alias of the builtin `int`, it can and should be replaced.

From the changelog of numpy (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations):
> For a long time, np.int has been an alias of the builtin int. This is repeatedly a cause of confusion for newcomers, and existed mainly for historic reasons. These aliases have been deprecated.