### PR TITLE
replace deprecated np.float and np.bool usage with their native variants

### DIFF
--- a/psg_utils/hypnogram/utils.py
+++ b/psg_utils/hypnogram/utils.py
@@ -138,7 +138,7 @@ def dense_to_sparse(array, period_length, time_unit: TimeUnit = TimeUnit.SECOND,
                              f"divisible by the period length of {period_length}, "
                              f"and allow_trim was set to False")
         durs[-1] -= trail
-    return np.asarray(inits, np.float), np.asarray(durs, np.float), stages
+    return np.asarray(inits, float), np.asarray(durs, float), stages
 
 
 def signal_dense_to_sparse(array, sample_rate, period_length, time_unit: TimeUnit = TimeUnit.SECOND, allow_trim=False):

--- a/psg_utils/preprocessing/strip_funcs.py
+++ b/psg_utils/preprocessing/strip_funcs.py
@@ -249,7 +249,7 @@ def convert_to_strip_mask(bool_mask):
         for i, elem in enumerate(arr):
             if not elem:
                 return i
-    bool_mask = np.array(bool_mask, dtype=np.bool, copy=True)
+    bool_mask = np.array(bool_mask, dtype=bool, copy=True)
     forward_false_idx = false_index(bool_mask)
     backward_false_idx = false_index(bool_mask[::-1])
     bool_mask[forward_false_idx:-backward_false_idx] = False


### PR DESCRIPTION
Thanks for the quick merge, and sorry to bother you again, but I ran into the same problems with `np.float` and decided to check all other deprecated fields mentioned in https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations, as well :smiley: 